### PR TITLE
pkg/volume: fix getExpectedBlockSize

### DIFF
--- a/pkg/volume/metrics_du_test.go
+++ b/pkg/volume/metrics_du_test.go
@@ -37,7 +37,7 @@ func getExpectedBlockSize(path string) int64 {
 		return 0
 	}
 
-	return int64(statfs.Bsize)
+	return int64(statfs.Frsize)
 }
 
 // TestMetricsDuGetCapacity tests that MetricsDu can read disk usage


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a test failure on filesystems that report a different block size and fragment size.

**Special notes for your reviewer**:

From: http://man7.org/linux/man-pages/man2/statfs.2.html
* statfs.Bsize: Optimal transfer block size
* statfs.Frsize: Fragment size (since Linux 2.6)

The expected block size is therefore fragment size.

**Release note**:
NONE
```
