### PR TITLE
Fix client ca hook pusher

### DIFF
--- a/pkg/master/client_ca_hook_test.go
+++ b/pkg/master/client_ca_hook_test.go
@@ -186,6 +186,30 @@ func TestWriteClientCAs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "skip on no change",
+			hook: ClientCARegistrationHook{
+				RequestHeaderUsernameHeaders:     []string{},
+				RequestHeaderGroupHeaders:        []string{},
+				RequestHeaderExtraHeaderPrefixes: []string{},
+				RequestHeaderCA:                  []byte("bar"),
+				RequestHeaderAllowedNames:        []string{},
+			},
+			preexistingObjs: []runtime.Object{
+				&api.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "extension-apiserver-authentication"},
+					Data: map[string]string{
+						"requestheader-username-headers":     `null`,
+						"requestheader-group-headers":        `null`,
+						"requestheader-extra-headers-prefix": `null`,
+						"requestheader-client-ca-file":       "bar",
+						"requestheader-allowed-names":        `null`,
+					},
+				},
+			},
+			expectedConfigMaps: map[string]*api.ConfigMap{},
+			expectUpdate:       false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
At the moment, if there is a Webhook that affects ConfigMaps in the `kube-system` and the webhook is unavailable, the `api-server` cannot start.

This change reduces the likelihood of the API server sending an update request and therefore the likelihood of hitting this reboot loop.

Before posting the update, check if the data within the ConfigMap has changed and only send the update if actually needed

Will PR this to the upstream if you think this looks good
